### PR TITLE
Feature/track non billable projects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,9 @@ GEM
       zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    annotate (2.7.5)
+    annotate (3.0.3)
       activerecord (>= 3.2, < 7.0)
-      rake (>= 10.4, < 13.0)
+      rake (>= 10.4, < 14.0)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.4)
@@ -109,7 +109,7 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.13.0)
     msgpack (1.3.0)
     nio4r (2.4.0)
     nokogiri (1.10.4)
@@ -215,7 +215,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.2.0)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -73,7 +73,7 @@ class ProjectsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def project_params
-      params.require(:project).permit(:name, :team_id,
+      params.require(:project).permit(:name, :team_id, :is_billable,
                                     contracts_attributes: [:id, :name, :_destroy,
                                                            :budget, :alias_list,
                                                            :start_date, :end_date])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def billable_tag element
+    klass = element.is_billable? ? 'warning' : 'info'
+    text = element.is_billable? ? 'Billable' : 'Non-billable'
+    content_tag(:span, class: "badge badge-#{klass}") do
+      text
+    end
+  end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -19,6 +19,7 @@ class Contract < ApplicationRecord
   has_many :full_reports
 
   validates_uniqueness_of :name
+  delegate :is_billable?, to: :project
 
   def alias_list
     self.alias.join(", ")

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -4,26 +4,27 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Project</th>
       <th>Name</th>
+      <th>Project</th>
       <th>Budget</th>
       <th>Costs</th>
-      <th></th>
     </tr>
   </thead>
 
   <tbody>
     <% @contracts.each do |contract| %>
       <tr>
-        <td><%= link_to contract.project.name, contract.project %></td>
-        <td><%= contract.name %></td>
+        <td><%= link_to contract.name, contract %></td>
+        <td>
+          <%= link_to contract.project.name, contract.project %>
+          <%= billable_tag(contract.project) %>
+        </td>
         <td>
           <%= number_to_currency(contract.budget, unit: '€')  %>
         </td>
         <td>
           <%= number_to_currency(contract.full_reports.sum(:cost), unit: '€') %>
         </td>
-        <td><%= link_to "Show", contract %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -8,6 +8,7 @@
 <p id="notice"><%= notice %></p>
 <p>
   <strong>Project:</strong> <%= link_to @contract.project.name, @contract.project  %>
+  <%= billable_tag(@contract.project) %>
 </p>
 <% unless @contract.alias.empty? %>
   <p>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :is_billable %>
+    <%= form.check_box :is_billable, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
     <%= form.label :team_id %>
     <%= form.collection_select :team_id, @teams, :id, :name, { include_blank: true }, class: 'form-control' %>
   </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -20,7 +20,7 @@
   <tbody>
     <% @projects.each do |project| %>
       <tr>
-        <td><%= project.name %></td>
+        <td><%= project.name %> <%= billable_tag(project) %></td>
         <td><%= project.team.try(:name) %></td>
         <td><%= project.contracts.size %></td>
         <td><%= number_to_currency(project.budget, unit: '€') %></td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,7 @@
-<% content_for :title, "Project - #{@project.name}" %>
+<% content_for :title do %>
+  <%= "Project - #{@project.name}" %>
+  <%= billable_tag(@project) %>
+<% end %>
 <p id="notice"><%= notice %></p>
 
 <% content_for :actions do

--- a/db/migrate/20191114174913_add_is_billable_to_projects.rb
+++ b/db/migrate/20191114174913_add_is_billable_to_projects.rb
@@ -1,0 +1,5 @@
+class AddIsBillableToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :is_billable, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_13_100705) do
+ActiveRecord::Schema.define(version: 2019_11_14_174913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_08_13_100705) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "team_id"
+    t.boolean "is_billable", default: true
     t.index ["team_id"], name: "index_projects_on_team_id"
   end
 


### PR DESCRIPTION
- Adds is_billable flag to projects;
- delegates is_billable from contracts to projects;
- enables editing is_billable flag;
- displays billable_tag in both contracts and projects pages.