### PR TITLE
Feature/contracts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,8 @@ gem 'chartkick'
 gem 'devise'
 gem 'scenic'
 
+# State machine
+gem 'aasm'
+
 # security update
 gem 'nokogiri', '>= 1.10.4'

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rubocop'
   gem 'rubocop-performance'
+  gem 'byebug'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (6.0.1)
       actionpack (= 6.0.1)
       nio4r (~> 2.0)
@@ -237,6 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   annotate
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -1,5 +1,5 @@
 class ContractsController < ApplicationController
-  before_action :set_contract, only: [:show, :reports]
+  before_action :set_contract, only: [:show, :reports, :update]
   def index
     @contracts = Contract.joins(:project).includes(:full_reports, :project)
       .order('projects.name ASC, contracts.name ASC')
@@ -28,6 +28,18 @@ class ContractsController < ApplicationController
         budget[:data][report.reporting_period_name] = @contract.budget&.to_f
       end
     @data = [contract, projected, aggregate, budget]
+  end
+
+  def update
+    respond_to do |format|
+      if @contract.update(contract_params)
+        format.html { redirect_to controller: 'contracts', action: 'index' }
+        format.json {render json: @contract, status: :ok}
+      else
+        format.html { render :edit }
+        format.json {render json: @contract.errors, status: :unprocessable_entity}
+      end
+    end
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -60,7 +72,10 @@ class ContractsController < ApplicationController
   def set_contract
     @contract = Contract.find(params[:id])
   end
-  def reporting_period_params
-    params.require(:contracts).permit(:state)
+  # def reporting_period_params
+  #   params.require(:contracts).permit(:state)
+  # end
+  def contract_params
+    params.require(:contract).permit(:id, :aasm_state, :state)
   end
 end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -1,10 +1,11 @@
 class ContractsController < ApplicationController
   before_action :set_contract, only: [:show, :reports, :update]
+  before_action :set_default_state, only: [:index]
   def index
     @contracts = Contract.joins(:project).includes(:full_reports, :project)
       .order('projects.name ASC, contracts.name ASC')
-    @states = Contract.aasm.states
-    @contracts = @contracts.with_status(params[:state]) if params[:state].present?
+    @states = Contract.aasm.states.map{|s| s.name}.prepend(:all)
+    @contracts = @contracts.with_status(@state) unless @state == 'all'
   end
 
   def show
@@ -72,9 +73,11 @@ class ContractsController < ApplicationController
   def set_contract
     @contract = Contract.find(params[:id])
   end
-  # def reporting_period_params
-  #   params.require(:contracts).permit(:state)
-  # end
+
+  def set_default_state
+   @state = params[:state].present? ? params[:state] : 'live'
+  end
+
   def contract_params
     params.require(:contract).permit(:id, :aasm_state, :state)
   end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -3,6 +3,8 @@ class ContractsController < ApplicationController
   def index
     @contracts = Contract.joins(:project).includes(:full_reports, :project)
       .order('projects.name ASC, contracts.name ASC')
+    @states = Contract.aasm.states
+    @contracts = @contracts.with_status(params[:state]) if params[:state].present?
   end
 
   def show
@@ -57,5 +59,8 @@ class ContractsController < ApplicationController
 
   def set_contract
     @contract = Contract.find(params[:id])
+  end
+  def reporting_period_params
+    params.require(:contracts).permit(:state)
   end
 end

--- a/app/helpers/contracts_helper.rb
+++ b/app/helpers/contracts_helper.rb
@@ -1,2 +1,14 @@
 module ContractsHelper
+  def event_color(state)
+    case state
+      when 'restart'
+        'btn-primary'
+      when 'finish'
+        'btn-warning'
+      when 'start'
+        'btn-success'
+      else
+        'btn-success'
+    end
+  end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -54,4 +54,8 @@ class Contract < ApplicationRecord
   def full_name
     "#{name} [#{project.name}]"
   end
+
+  def self.with_status(status)
+    where(aasm_state: status )
+  end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -14,6 +14,28 @@
 #
 
 class Contract < ApplicationRecord
+  include AASM
+
+  aasm do
+    state :proposal, initial: true
+    state :live
+    state :finished
+    state :archived
+    event :start do
+      transitions from: :proposal, to: :live
+    end
+    event :finish do
+      transitions from: :live, to: :finished
+    end
+    event :restart do
+      transitions from: [:finished, :archived], to: :live
+    end
+    event :archive do
+      transitions from: [:proposal, :finished], to: :archive
+    end
+
+  end
+
   belongs_to :project
   has_many :report_parts, dependent: :destroy
   has_many :full_reports

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -55,6 +55,12 @@ class Contract < ApplicationRecord
     "#{name} [#{project.name}]"
   end
 
+  def next_event
+    self.aasm.events(permitted: true).first.name.to_s
+  end
+  def next_state
+    self.aasm.states(permitted: true).first.name.to_s
+  end
   def self.with_status(status)
     where(aasm_state: status )
   end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -20,7 +20,6 @@ class Contract < ApplicationRecord
     state :proposal, initial: true
     state :live
     state :finished
-    state :archived
     event :start do
       transitions from: :proposal, to: :live
     end
@@ -28,12 +27,8 @@ class Contract < ApplicationRecord
       transitions from: :live, to: :finished
     end
     event :restart do
-      transitions from: [:finished, :archived], to: :live
+      transitions from: :finished, to: :live
     end
-    event :archive do
-      transitions from: [:proposal, :finished], to: :archive
-    end
-
   end
 
   belongs_to :project

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -37,7 +37,7 @@
           <%= form_with(model: contract, method: :patch, local: true) do |form| %>
             <div class="form-group">
               <%= form.hidden_field(:aasm_state, value: contract.next_state) %>
-              <%= form.submit contract.next_event, class: "btn btn-primary" %>
+              <%= form.submit contract.next_event, class: "btn #{event_color(contract.next_event)}" %>
             </div>
         <% end %>
         </td>

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -4,7 +4,7 @@
 <%= form_with(url: 'contracts#index', method: :get, local: true) do |form| %>
   <div class="form-group">
     <%= form.label :status %>
-    <%= form.select :state, options_from_collection_for_select(@states, :name, :name, selected: params[:state]), { prompt: true }, class: "form-control", onchange: 'this.form.submit();' %>
+    <%= form.select :state, options_from_collection_for_select(@states, :name, :name, selected: params[:state]), { prompt: "All" }, class: "form-control", onchange: 'this.form.submit();' %>
   </div>
 <% end %>
 
@@ -15,6 +15,7 @@
       <th>Project</th>
       <th>Budget</th>
       <th>Costs</th>
+      <th>Action</th>
     </tr>
   </thead>
 
@@ -31,6 +32,14 @@
         </td>
         <td>
           <%= number_to_currency(contract.full_reports.sum(:cost), unit: '€') %>
+        </td>
+        <td>
+          <%= form_with(model: contract, method: :patch, local: true) do |form| %>
+            <div class="form-group">
+              <%= form.hidden_field(:aasm_state, value: contract.next_state) %>
+              <%= form.submit contract.next_event, class: "btn btn-primary" %>
+            </div>
+        <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -4,7 +4,7 @@
 <%= form_with(url: 'contracts#index', method: :get, local: true) do |form| %>
   <div class="form-group">
     <%= form.label :status %>
-    <%= form.select :state, options_from_collection_for_select(@states, :name, :name, selected: params[:state]), { prompt: "All" }, class: "form-control", onchange: 'this.form.submit();' %>
+    <%= form.select :state, options_for_select(@states, selected: @state), {}, class: "form-control", onchange: 'this.form.submit();' %>
   </div>
 <% end %>
 

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -1,6 +1,13 @@
 <% content_for :title, "Contracts" %>
 <p id="notice"><%= notice %></p>
 
+<%= form_with(url: 'contracts#index', method: :get, local: true) do |form| %>
+  <div class="form-group">
+    <%= form.label :status %>
+    <%= form.select :state, options_from_collection_for_select(@states, :name, :name, selected: params[:state]), { prompt: true }, class: "form-control", onchange: 'this.form.submit();' %>
+  </div>
+<% end %>
+
 <table class="table">
   <thead>
     <tr>

--- a/app/views/reporting_periods/show.html.erb
+++ b/app/views/reporting_periods/show.html.erb
@@ -19,10 +19,7 @@ end %>
 <%= form_with(url: @reporting_period, method: :get, local: true) do |form| %>
   <div class="form-group">
     <%= form.label :role_id %>
-    <%= form.select :role_id, options_from_collection_for_select(@roles, :id, :name, selected: params[:role_id]), { prompt: true }, class: "form-control" %>
-  </div>
-  <div class="actions">
-    <%= form.submit "Filter" %>
+    <%= form.select :role_id, options_from_collection_for_select(@roles, :id, :name, selected: params[:role_id]), { prompt: true }, class: "form-control", onchange: 'this.form.submit();' %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :reports, only: [:edit, :update]
   resources :users
   resources :projects
-  resources :contracts, only: [:index, :show] do
+  resources :contracts, only: [:index, :show, :update] do
     get 'reports', on: :member
   end
   resources :roles

--- a/db/migrate/20191125094827_add_aasm_state_to_contracts.rb
+++ b/db/migrate/20191125094827_add_aasm_state_to_contracts.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToContracts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :contracts, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_18_235738) do
+ActiveRecord::Schema.define(version: 2019_11_25_094827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_235738) do
     t.string "alias", default: [], array: true
     t.date "start_date"
     t.date "end_date"
+    t.string "aasm_state"
     t.index ["alias"], name: "index_contracts_on_alias", using: :gin
     t.index ["project_id"], name: "index_contracts_on_project_id"
   end


### PR DESCRIPTION
On this PR:

- Added Act as State Machine gem
- Migration to include the status column in the DB
- Added filter by status in contract page
- Added a button in every row of contracts#index to commute the status

Note: All contracts are on the proposal status by default, we may run a command on the console to move them to live or do it manually in the admin.