### PR TITLE
Feature/budget breakdown functional area

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -22,6 +22,7 @@ class ContractsController < ApplicationController
 
   def new
     @contract = Contract.new
+    @contract.build_budget_lines
     @states = Contract.aasm.states.map(&:name).prepend(:all)
     @projects = Project.order(:name)
   end
@@ -48,6 +49,7 @@ class ContractsController < ApplicationController
   def edit
     @projects = Project.order(:name)
     @states = Contract.aasm.states.map(&:name).prepend(:all)
+    @contract.build_budget_lines
   end
 
   def show
@@ -155,6 +157,8 @@ class ContractsController < ApplicationController
                                      :aasm_state, :state,
                                      :percent_complete, :project_id,
                                      :name, :budget, :summary,
-                                     :alias_list, :start_date, :end_date)
+                                     :start_date, :end_date,
+                                     budget_lines_attributes: [:id, :percentage,
+                                                               :role_id, :details])
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -86,9 +86,8 @@ class ProjectsController < ApplicationController
   def project_params
     params.require(:project).permit(:name, :team_id, :is_billable,
                                     contracts_attributes: [:id, :name, :_destroy,
-                                                           :budget, :alias_list,
-                                                           :code, :notes, :summary,
-                                                           :aasm_state,
+                                                           :budget, :code, :notes,
+                                                           :summary, :aasm_state,
                                                            :start_date, :end_date])
   end
 end

--- a/app/models/budget_line.rb
+++ b/app/models/budget_line.rb
@@ -1,0 +1,4 @@
+class BudgetLine < ApplicationRecord
+  belongs_to :contract
+  belongs_to :role, optional: true
+end

--- a/app/views/contracts/_budget_line_fields.html.erb
+++ b/app/views/contracts/_budget_line_fields.html.erb
@@ -1,0 +1,23 @@
+<% is_new_record = form.object.new_record? %>
+
+<%= content_tag :tr do %>
+  <td>
+    <% if form.object.role %>
+      <%= form.object.role&.name %>
+      <%= form.hidden_field :role_id %>
+    <% else %>
+      <div class="form-group">
+        <%= form.text_field :details, value: 'Other costs', class: 'form-control' %>
+      </div>
+    <% end %>
+  </td>
+  <td>
+    <div class="input-group">
+      <%= form.text_field :percentage, class: 'form-control',
+          data: { action: 'change->report-percentages#recalc', target: 'report-percentages.source' }%>
+      <div class="input-group-append">
+        <div class="input-group-text">%</div>
+      </div>
+    </div>
+  </td>
+<% end %>

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -1,8 +1,9 @@
-<div class="row">
-  <div class="col-md-12">
-    <div class="main-card mb-3 card">
-      <div class="card-body">
-        <%= form_with(model: contract, local: true) do |form| %>
+<%= form_with(model: contract, local: true) do |form| %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title">Details</h5>
           <% if contract.errors.any? %>
             <div id="error_explanation">
               <h2><%= pluralize(contract.errors.count, "error") %> prohibited this contract from being saved:</h2>
@@ -87,8 +88,15 @@
               <%= form.text_field :end_date, class: 'form-control', data: {provide: 'datepicker'} %>
             </div>
           </div>
-          <hr>
-          <h5>Budget and breakdown</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title">Budget and breakdown</h5>
 
           <div class="position-relative row form-group">
             <%= form.label :budget, class: "col-sm-2 col-form-label" %>
@@ -135,8 +143,8 @@
               <%= form.submit "Submit", class: "btn btn-primary" %>
             </div>
           </div>
-        <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -49,18 +49,6 @@
               <%= form.text_area :summary, class: 'form-control' %>
             </div>
           </div>
-
-          <div class="position-relative row form-group">
-            <%= form.label :budget, class: "col-sm-2 col-form-label" %>
-            <div class="col-sm-10">
-              <div class="input-group">
-                <div class="input-group-prepend">
-                  <div class="input-group-text">€</div>
-                </div>
-                <%= form.text_field :budget, class: 'form-control' %>
-              </div>
-            </div>
-          </div>
           <% unless contract.new_record? %>
             <div class="position-relative row form-group">
               <%= form.label :percent_complete, 'Estimated completion', class: "col-sm-2 col-form-label" %>
@@ -99,6 +87,48 @@
               <%= form.text_field :end_date, class: 'form-control', data: {provide: 'datepicker'} %>
             </div>
           </div>
+          <hr>
+          <h5>Budget and breakdown</h5>
+
+          <div class="position-relative row form-group">
+            <%= form.label :budget, class: "col-sm-2 col-form-label" %>
+            <div class="col-sm-10">
+              <div class="input-group">
+                <div class="input-group-prepend">
+                  <div class="input-group-text">€</div>
+                </div>
+                <%= form.text_field :budget, class: 'form-control' %>
+              </div>
+            </div>
+          </div>
+
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Functional Area</th>
+                <th>Percentage</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody data-controller="report-percentages">
+              <%= form.fields_for :budget_lines do |builder| %>
+                <%= render 'budget_line_fields', form: builder %>
+              <% end %>
+              <tr class="nested-list__actions" data-target="nested-list.links">
+                <th>
+                  Total
+                </th>
+                <th>
+                  <div class="input-group">
+                    <input type="text" data-target="report-percentages.display" disabled value="<%= contract.budget_lines.sum(:percentage) %>" class="form-control">
+                    <div class="input-group-append">
+                      <div class="input-group-text">%</div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </tbody>
+          </table>
 
           <div class="position-relative row form-group">
             <div class="col-sm-10 offset-sm-2">

--- a/app/views/contracts/reports.html.erb
+++ b/app/views/contracts/reports.html.erb
@@ -45,7 +45,7 @@
               <th>Period</th>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Percentage</th>
               <th>Days</th>
               <th>Cost</th>

--- a/app/views/contracts/reports.html.erb
+++ b/app/views/contracts/reports.html.erb
@@ -4,11 +4,6 @@
 <p>
   <strong>Project:</strong> <%= link_to @contract.project.name, @contract.project  %>
 </p>
-<% unless @contract.alias.empty? %>
-  <p>
-    <strong>Alias:</strong> <%= @contract.alias_list %>
-  </p>
-<% end %>
 
 <%= form_with(url: reports_contract_path(@contract), method: :get, local: true) do |form| %>
   <div class="form-group">

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -134,7 +134,8 @@
           <thead>
             <tr>
               <th>Functional Area</th>
-              <th>%</th>
+              <th>% in contract</th>
+              <th>% reported</th>
               <th>Total days</th>
             </tr>
           </thead>
@@ -143,12 +144,13 @@
               <% role_days = @days_per_role.where(role_id: role.id).first&.days || 0 %>
               <tr>
                 <td><%= link_to role.name, role %></td>
+                <td><%= @contract.budget_lines.where(role: role.id).first&.percentage %></td>
                 <td><%= @total_days && (role_days / @total_days.to_f * 100).round(2) %>%</td>
                 <td><%= role_days  %></td>
               </tr>
             <% end %>
             <tr>
-              <td colspan="2"><strong>Total</strong></td>
+              <td colspan="3"><strong>Total</strong></td>
               <td><%= @total_days %></td>
             </tr>
           </tbody>

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -133,7 +133,7 @@
         <table class="table table-bordered">
           <thead>
             <tr>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>%</th>
               <th>Total days</th>
             </tr>
@@ -169,7 +169,7 @@
               <th>Period</th>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Percentage</th>
               <th>Days</th>
               <th>Cost</th>

--- a/app/views/contracts/team.html.erb
+++ b/app/views/contracts/team.html.erb
@@ -10,7 +10,7 @@
             <thead>
               <tr>
                 <th rowspan="2">Name</th>
-                <th rowspan="2">Role</th>
+                <th rowspan="2">Functional Area</th>
                 <th colspan="<%= @reporting_periods.count %>" class="text-center">
                   days in the last 4 months
                 </th>

--- a/app/views/reporting_periods/reports.html.erb
+++ b/app/views/reporting_periods/reports.html.erb
@@ -18,7 +18,7 @@
             <tr>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Contract</th>
               <th>Percentage</th>
               <th>Days</th>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,7 +10,7 @@
             <tr>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Reporting period</th>
               <th colspan="3"></th>
             </tr>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <strong>Role:</strong>
+  <strong>Functional Area:</strong>
   <%= @report.role_id %>
 </p>
 

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Editing Role" %>
+<% content_for :title, "Editing Functional Area" %>
 <% content_for :actions,
   link_to('Show', @role, class: 'btn btn-sm btn-outline-primary').concat(
     link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary')) %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "Roles" %>
+<% content_for :title, "Functional Areas" %>
 <% content_for :actions,
-  link_to('New Role', new_role_path, class: 'btn btn-sm btn-outline-primary') %>
+  link_to('New Functional Area', new_role_path, class: 'btn btn-sm btn-outline-primary') %>
 
 <div class="row">
   <div class="col-md-12">

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "New Role" %>
+<% content_for :title, "New Functional Area" %>
 <% content_for :actions,
   link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary') %>
 

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Role - #{@role.name}" %>
+<% content_for :title, "Functional Area - #{@role.name}" %>
 <% content_for :actions,
   link_to('Edit', edit_role_path(@role), class: 'btn btn-sm btn-outline-primary').concat(
     link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary')) %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -83,7 +83,7 @@
         <li>
           <%= link_to :roles, class: (controller_name == 'roles' && 'mm-active') do %>
             <i class="metismenu-icon"></i>
-            Roles
+            Functional Areas
           <% end %>
         </li>
         <li>

--- a/app/views/teams/members.html.erb
+++ b/app/views/teams/members.html.erb
@@ -9,7 +9,7 @@
           <thead>
             <tr>
               <th>Name</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Email</th>
               <th></th>
             </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
             <tr>
               <th>Name</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <% if current_user.admin? %>
                 <th>Rate</th>
                 <th>Dedication</th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,7 +21,7 @@
         </p>
 
         <p>
-          <strong>Roles:</strong>
+          <strong>Functional Area:</strong>
           <%= @user.role&.name %>
         </p>
 

--- a/db/migrate/20200208175311_create_budget_lines.rb
+++ b/db/migrate/20200208175311_create_budget_lines.rb
@@ -1,0 +1,12 @@
+class CreateBudgetLines < ActiveRecord::Migration[6.0]
+  def change
+    create_table :budget_lines do |t|
+      t.references :contract, null: false, foreign_key: true
+      t.references :role, foreign_key: true
+      t.float :percentage
+      t.string :details
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_05_174106) do
+ActiveRecord::Schema.define(version: 2020_02_08_175311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "budget_lines", force: :cascade do |t|
+    t.bigint "contract_id", null: false
+    t.bigint "role_id"
+    t.float "percentage"
+    t.string "details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["contract_id"], name: "index_budget_lines_on_contract_id"
+    t.index ["role_id"], name: "index_budget_lines_on_role_id"
+  end
 
   create_table "contracts", force: :cascade do |t|
     t.string "name"
@@ -129,6 +140,8 @@ ActiveRecord::Schema.define(version: 2020_02_05_174106) do
     t.index ["team_id"], name: "index_users_on_team_id"
   end
 
+  add_foreign_key "budget_lines", "contracts"
+  add_foreign_key "budget_lines", "roles"
   add_foreign_key "contracts", "projects"
   add_foreign_key "non_staff_costs", "contracts"
   add_foreign_key "non_staff_costs", "reporting_periods"

--- a/test/factories/budget_lines.rb
+++ b/test/factories/budget_lines.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :budget_line do
+    contract { nil }
+    role { nil }
+    percentage { 1.5 }
+    details { "MyString" }
+  end
+end

--- a/test/models/budget_line_test.rb
+++ b/test/models/budget_line_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BudgetLineTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This Pull Requests adds the possibility of tracking percentage of budget of a contract per functional area.

This information is managed on the contract edit page:

![Screenshot 2020-02-10 at 08 49 49](https://user-images.githubusercontent.com/10764/74134360-55a83300-4be2-11ea-9672-ea944d660dab.png)
![Screenshot 2020-02-10 at 08 49 53](https://user-images.githubusercontent.com/10764/74134364-593bba00-4be2-11ea-89be-e5c2e371f17a.png)

And is displayed on the contract show page, on the "Time per role" table.

![Screenshot 2020-02-10 at 08 47 23](https://user-images.githubusercontent.com/10764/74134189-fc400400-4be1-11ea-8e08-19d406936e57.png)


Besides the existing functional areas, I made available an extra category defaulting to "Other" that could be used for either flexible time or non staff time. But the mechanics might need tuning for this one.