### PR TITLE
Feature/progress per reporting period

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,7 @@ Style/ClassAndModuleChildren:
 Style/MethodDefParentheses:
     Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   Exclude:
     - 'db/**/*'

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -22,6 +22,7 @@ class ContractsController < ApplicationController
 
   def new
     @contract = Contract.new
+    @contract.build_budget_lines
     @states = Contract.aasm.states.map(&:name).prepend(:all)
     @projects = Project.order(:name)
   end
@@ -48,6 +49,7 @@ class ContractsController < ApplicationController
   def edit
     @projects = Project.order(:name)
     @states = Contract.aasm.states.map(&:name).prepend(:all)
+    @contract.build_budget_lines
   end
 
   def show
@@ -155,6 +157,8 @@ class ContractsController < ApplicationController
                                      :aasm_state, :state,
                                      :percent_complete, :project_id,
                                      :name, :budget, :summary,
-                                     :alias_list, :start_date, :end_date)
+                                     :start_date, :end_date,
+                                     budget_lines_attributes: [:id, :percentage,
+                                                               :role_id, :details])
   end
 end

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -1,0 +1,50 @@
+class ProgressReportsController < ApplicationController
+  before_action :set_contract
+  before_action :set_progress_report, only: [:edit, :update], only: [:edit, :update]
+  before_action :set_vars, only: [:new, :edit]
+
+  def new
+    @progress_report = @contract.progress_reports.new(reporting_period: @active_period)
+  end
+
+  def create
+    @progress_report = @contract.progress_reports.new(progress_report_params)
+    if @progress_report.save
+      redirect_to @contract, notice: 'Progress report was successefully created.'
+    else
+      set_vars
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @progress_report.update(progress_report_params)
+      redirect_to @contract
+    else
+      set_vars
+      render :edit
+    end
+  end
+
+  private
+
+  def set_progress_report
+    @progress_report = ProgressReport.find(params[:id])
+  end
+
+  def set_contract
+    @contract = Contract.find(params[:contract_id])
+  end
+
+  def set_vars
+    @reporting_periods = ReportingPeriod.order(date: :desc)
+    @active_period = ReportingPeriod.where(aasm_state: 'active').first
+  end
+
+  def progress_report_params
+    params.require(:progress_report).permit(:reporting_period_id,
+                                            :percentage)
+  end
+end

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -1,6 +1,6 @@
 class ProgressReportsController < ApplicationController
   before_action :set_contract
-  before_action :set_progress_report, only: [:edit, :update], only: [:edit, :update]
+  before_action :set_progress_report, only: [:edit, :update]
   before_action :set_vars, only: [:new, :edit]
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -86,9 +86,8 @@ class ProjectsController < ApplicationController
   def project_params
     params.require(:project).permit(:name, :team_id, :is_billable,
                                     contracts_attributes: [:id, :name, :_destroy,
-                                                           :budget, :alias_list,
-                                                           :code, :notes, :summary,
-                                                           :aasm_state,
+                                                           :budget, :code, :notes,
+                                                           :summary, :aasm_state,
                                                            :start_date, :end_date])
   end
 end

--- a/app/javascript/stylesheets/architect-ui/base.scss
+++ b/app/javascript/stylesheets/architect-ui/base.scss
@@ -66,7 +66,7 @@
 @import "elements/cards";
 // @import "elements/tabs";
 // @import "elements/accordions";
-// @import "elements/modals";
+//@import "elements/modals";
 // @import "elements/loaders";
 // @import "elements/progressbar";
 // @import "elements/timeline";

--- a/app/models/budget_line.rb
+++ b/app/models/budget_line.rb
@@ -1,0 +1,4 @@
+class BudgetLine < ApplicationRecord
+  belongs_to :contract
+  belongs_to :role, optional: true
+end

--- a/app/models/budget_line.rb
+++ b/app/models/budget_line.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: budget_lines
+#
+#  id          :bigint           not null, primary key
+#  contract_id :bigint           not null
+#  role_id     :bigint
+#  percentage  :float
+#  details     :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class BudgetLine < ApplicationRecord
   belongs_to :contract
   belongs_to :role, optional: true

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -45,6 +45,8 @@ class Contract < ApplicationRecord
   accepts_nested_attributes_for :budget_lines, allow_destroy: true,
                                 reject_if: :reject_empty_lines
 
+  has_many :progress_reports
+
   validates_uniqueness_of :name # , :code
   delegate :is_billable?, to: :project
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -45,7 +45,7 @@ class Contract < ApplicationRecord
   has_many :monthly_incomes
   has_many :budget_lines
   accepts_nested_attributes_for :budget_lines, allow_destroy: true,
-                                reject_if: :reject_empty_lines
+                                               reject_if: :reject_empty_lines
 
   has_many :progress_reports
 
@@ -54,7 +54,7 @@ class Contract < ApplicationRecord
 
   before_destroy :no_report_parts
 
-  def previous_progress_report progress_report=nil
+  def previous_progress_report progress_report = nil
     p_reports = progress_reports.joins(:reporting_period)
       .order('reporting_periods.date DESC')
 
@@ -135,8 +135,8 @@ class Contract < ApplicationRecord
   def reject_empty_lines(attributes)
     exists = attributes['id'].present?
     empty = attributes['percentage'].blank? || attributes['percentage'].to_f <= 0.0
-    attributes.merge!({_destroy: 1}) if exists && empty
-    return (!exists && empty)
+    attributes.merge!(_destroy: 1) if exists && empty
+    !exists && empty
   end
 
   def no_report_parts

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -1,0 +1,4 @@
+class ProgressReport < ApplicationRecord
+  belongs_to :reporting_period
+  belongs_to :contract
+end

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -23,23 +23,22 @@ class ProgressReport < ApplicationRecord
   validates :reporting_period_id, :contract_id, :percentage, presence: true
   validate :bounded_progress
 
-
   private
 
   def calculate_delta
     prev = contract.previous_progress_report(self)
 
     self.delta = if prev
-                   self.percentage - prev.percentage
+                   percentage - prev.percentage
                  else
-                   self.percentage
+                   percentage
                  end
   end
 
   def bounded_progress
     prev = contract.previous_progress_report(self)
-    if prev && prev.percentage >= self.percentage
-      errors.add(:percentage, 'Progress can\'t be lower than previously reported progress')
-    end
+    return unless prev && prev.percentage >= percentage
+
+    errors.add(:percentage, 'Progress can\'t be lower than previously reported progress')
   end
 end

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -1,4 +1,45 @@
+# == Schema Information
+#
+# Table name: progress_reports
+#
+#  id                  :bigint           not null, primary key
+#  reporting_period_id :bigint           not null
+#  contract_id         :bigint           not null
+#  percentage          :float
+#  delta               :float
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 class ProgressReport < ApplicationRecord
   belongs_to :reporting_period
   belongs_to :contract
+
+  delegate :date, to: :reporting_period
+
+  before_save :calculate_delta
+
+  validates_uniqueness_of :reporting_period_id, scope: :contract_id
+  validates :reporting_period_id, :contract_id, :percentage, presence: true
+  validate :bounded_progress
+
+
+  private
+
+  def calculate_delta
+    prev = contract.previous_progress_report(self)
+
+    self.delta = if prev
+                   self.percentage - prev.percentage
+                 else
+                   self.percentage
+                 end
+  end
+
+  def bounded_progress
+    prev = contract.previous_progress_report(self)
+    if prev && prev.percentage >= self.percentage
+      errors.add(:percentage, 'Progress can\'t be lower than previously reported progress')
+    end
+  end
 end

--- a/app/models/reporting_period.rb
+++ b/app/models/reporting_period.rb
@@ -44,6 +44,8 @@ class ReportingPeriod < ApplicationRecord
 
   validates_uniqueness_of :date
 
+  scope :active_period, -> { where(aasm_state: 'active').first }
+
   def display_name
     date.strftime('%B %Y')
   end

--- a/app/models/reporting_period.rb
+++ b/app/models/reporting_period.rb
@@ -44,7 +44,6 @@ class ReportingPeriod < ApplicationRecord
 
   validates_uniqueness_of :date
 
-
   def self.active_period
     ReportingPeriod.where(aasm_state: 'active').first
   end

--- a/app/models/reporting_period.rb
+++ b/app/models/reporting_period.rb
@@ -44,7 +44,10 @@ class ReportingPeriod < ApplicationRecord
 
   validates_uniqueness_of :date
 
-  scope :active_period, -> { where(aasm_state: 'active').first }
+
+  def self.active_period
+    ReportingPeriod.where(aasm_state: 'active').first
+  end
 
   def display_name
     date.strftime('%B %Y')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ApplicationRecord
   validates_uniqueness_of :email, :name
 
   def current_report
-    reporting_period = ReportingPeriod.where(aasm_state: 'active').first
+    reporting_period = ReportingPeriod.active_period
     return nil unless reporting_period
 
     reports.where(reporting_period_id: reporting_period.id).first || reports

--- a/app/views/contracts/_budget_line_fields.html.erb
+++ b/app/views/contracts/_budget_line_fields.html.erb
@@ -1,0 +1,23 @@
+<% is_new_record = form.object.new_record? %>
+
+<%= content_tag :tr do %>
+  <td>
+    <% if form.object.role %>
+      <%= form.object.role&.name %>
+      <%= form.hidden_field :role_id %>
+    <% else %>
+      <div class="form-group">
+        <%= form.text_field :details, value: 'Other costs', class: 'form-control' %>
+      </div>
+    <% end %>
+  </td>
+  <td>
+    <div class="input-group">
+      <%= form.text_field :percentage, class: 'form-control',
+          data: { action: 'change->report-percentages#recalc', target: 'report-percentages.source' }%>
+      <div class="input-group-append">
+        <div class="input-group-text">%</div>
+      </div>
+    </div>
+  </td>
+<% end %>

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -1,8 +1,9 @@
-<div class="row">
-  <div class="col-md-12">
-    <div class="main-card mb-3 card">
-      <div class="card-body">
-        <%= form_with(model: contract, local: true) do |form| %>
+<%= form_with(model: contract, local: true) do |form| %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title">Details</h5>
           <% if contract.errors.any? %>
             <div id="error_explanation">
               <h2><%= pluralize(contract.errors.count, "error") %> prohibited this contract from being saved:</h2>
@@ -87,8 +88,15 @@
               <%= form.text_field :end_date, class: 'form-control', data: {provide: 'datepicker'} %>
             </div>
           </div>
-          <hr>
-          <h5>Budget and breakdown</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title">Budget and breakdown</h5>
 
           <div class="position-relative row form-group">
             <%= form.label :budget, class: "col-sm-2 col-form-label" %>
@@ -135,8 +143,8 @@
               <%= form.submit "Submit", class: "btn btn-primary" %>
             </div>
           </div>
-        <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -49,18 +49,6 @@
               <%= form.text_area :summary, class: 'form-control' %>
             </div>
           </div>
-
-          <div class="position-relative row form-group">
-            <%= form.label :budget, class: "col-sm-2 col-form-label" %>
-            <div class="col-sm-10">
-              <div class="input-group">
-                <div class="input-group-prepend">
-                  <div class="input-group-text">€</div>
-                </div>
-                <%= form.text_field :budget, class: 'form-control' %>
-              </div>
-            </div>
-          </div>
           <% unless contract.new_record? %>
             <div class="position-relative row form-group">
               <%= form.label :percent_complete, 'Estimated completion', class: "col-sm-2 col-form-label" %>
@@ -99,6 +87,48 @@
               <%= form.text_field :end_date, class: 'form-control', data: {provide: 'datepicker'} %>
             </div>
           </div>
+          <hr>
+          <h5>Budget and breakdown</h5>
+
+          <div class="position-relative row form-group">
+            <%= form.label :budget, class: "col-sm-2 col-form-label" %>
+            <div class="col-sm-10">
+              <div class="input-group">
+                <div class="input-group-prepend">
+                  <div class="input-group-text">€</div>
+                </div>
+                <%= form.text_field :budget, class: 'form-control' %>
+              </div>
+            </div>
+          </div>
+
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Functional Area</th>
+                <th>Percentage</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody data-controller="report-percentages">
+              <%= form.fields_for :budget_lines do |builder| %>
+                <%= render 'budget_line_fields', form: builder %>
+              <% end %>
+              <tr class="nested-list__actions" data-target="nested-list.links">
+                <th>
+                  Total
+                </th>
+                <th>
+                  <div class="input-group">
+                    <input type="text" data-target="report-percentages.display" disabled value="<%= contract.budget_lines.sum(:percentage) %>" class="form-control">
+                    <div class="input-group-append">
+                      <div class="input-group-text">%</div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </tbody>
+          </table>
 
           <div class="position-relative row form-group">
             <div class="col-sm-10 offset-sm-2">

--- a/app/views/contracts/_progress_modal.html.erb
+++ b/app/views/contracts/_progress_modal.html.erb
@@ -1,0 +1,34 @@
+<div class="modal fade bd-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="progressModal" aria-hidden="true" style="display: none;" id="progressModal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="progressModalTitle">Logged Progress</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Period</th>
+              <th>Progress</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @contract.progress_reports
+              .joins(:reporting_period).order('reporting_periods.date DESC').each do |pr| %>
+              <tr>
+                <td><%= pr.reporting_period.display_name %></td>
+                <td><%= pr.percentage %>%</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/contracts/reports.html.erb
+++ b/app/views/contracts/reports.html.erb
@@ -45,7 +45,7 @@
               <th>Period</th>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Percentage</th>
               <th>Days</th>
               <th>Cost</th>

--- a/app/views/contracts/reports.html.erb
+++ b/app/views/contracts/reports.html.erb
@@ -4,11 +4,6 @@
 <p>
   <strong>Project:</strong> <%= link_to @contract.project.name, @contract.project  %>
 </p>
-<% unless @contract.alias.empty? %>
-  <p>
-    <strong>Alias:</strong> <%= @contract.alias_list %>
-  </p>
-<% end %>
 
 <%= form_with(url: reports_contract_path(@contract), method: :get, local: true) do |form| %>
   <div class="form-group">

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "Contract - #{@contract.name} - #{@contract.aasm_state.humanize}" %>
 <%= render 'actions', contract: @contract %>
+<% content_for :modals, render('progress_modal', contract: @contract) %>
 
 <% if @contract.start_date <= Date.parse('01/10/2018') || @contract.end_date <= Date.parse('01/10/2018') %>
   <div class="alert alert-warning alert-dismissible fade show" role="alert">
@@ -60,7 +61,7 @@
           <strong>Estimated progress:</strong>
           <%= result_with_color(@contract.previous_progress_report&.percentage || 0.0) %>%
           <% if @contract.previous_progress_report %>
-            <%= link_to 'View all' %>
+            <%= link_to 'View all', '#', data: {toggle: 'modal', target: '#progressModal'} %>
             |
             <%= link_to 'Edit', edit_contract_progress_report_path(@contract, @contract.previous_progress_report) %>
           <% end %>
@@ -134,8 +135,6 @@
     </div>
   </div>
 </div>
-
-
 
 <div class="row">
   <div class="col-md-12">

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -134,7 +134,8 @@
           <thead>
             <tr>
               <th>Functional Area</th>
-              <th>%</th>
+              <th>% in contract</th>
+              <th>% reported</th>
               <th>Total days</th>
             </tr>
           </thead>
@@ -143,12 +144,13 @@
               <% role_days = @days_per_role.where(role_id: role.id).first&.days || 0 %>
               <tr>
                 <td><%= link_to role.name, role %></td>
+                <td><%= @contract.budget_lines.where(role: role.id).first&.percentage %></td>
                 <td><%= @total_days && (role_days / @total_days.to_f * 100).round(2) %>%</td>
                 <td><%= role_days  %></td>
               </tr>
             <% end %>
             <tr>
-              <td colspan="2"><strong>Total</strong></td>
+              <td colspan="3"><strong>Total</strong></td>
               <td><%= @total_days %></td>
             </tr>
           </tbody>

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -133,7 +133,7 @@
         <table class="table table-bordered">
           <thead>
             <tr>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>%</th>
               <th>Total days</th>
             </tr>
@@ -169,7 +169,7 @@
               <th>Period</th>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Percentage</th>
               <th>Days</th>
               <th>Cost</th>

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -23,6 +23,12 @@
         <p>
           <strong>Code:</strong> <%= @contract.code %>
         </p>
+        <p>
+          <strong>Start Date:</strong> <%= @contract.start_date&.strftime('%d/%B/%Y') %>
+        </p>
+        <p>
+          <strong>End Date:</strong> <%= @contract.end_date&.strftime('%d/%B/%Y') %>
+        </p>
         <% if @contract.notes.present? %>
           <p>
             <strong>Notes:</strong> <%= @contract.notes %>
@@ -39,12 +45,6 @@
   <div class="col-md-6">
     <div class="main-card mb-3 card">
       <div class="card-body">
-        <p>
-          <strong>Start Date:</strong> <%= @contract.start_date&.strftime('%d/%B/%Y') %>
-        </p>
-        <p>
-          <strong>End Date:</strong> <%= @contract.end_date&.strftime('%d/%B/%Y') %>
-        </p>
         <p><strong>Budget:</strong> <%= @contract.budget ? number_to_currency(@contract.budget) : "Not defined" %></p>
         <h5 class="card-title">Burn</h5>
         <p>

--- a/app/views/contracts/show.html.erb
+++ b/app/views/contracts/show.html.erb
@@ -46,7 +46,6 @@
     <div class="main-card mb-3 card">
       <div class="card-body">
         <p><strong>Budget:</strong> <%= @contract.budget ? number_to_currency(@contract.budget) : "Not defined" %></p>
-        <h5 class="card-title">Burn</h5>
         <p>
           <strong>Reported burn:</strong>
           <%= number_to_currency(@contract.total_burn) %>
@@ -57,12 +56,25 @@
             <%= number_to_currency(@contract.total_burn(true)) %>
           </p>
         <% end %>
-        <% if @contract.percent_complete && @contract.budget %>
-          <p>
+        <p>
+          <strong>Estimated progress:</strong>
+          <%= result_with_color(@contract.previous_progress_report&.percentage || 0.0) %>%
+          <% if @contract.previous_progress_report %>
+            <%= link_to 'View all' %>
+            |
+            <%= link_to 'Edit', edit_contract_progress_report_path(@contract, @contract.previous_progress_report) %>
+          <% end %>
+          <% if @contract.previous_progress_report&.reporting_period != ReportingPeriod.active_period %>
+            |
+            <%= link_to 'Add', new_contract_progress_report_path(@contract) %>
+          <% end %>
+        </p>
+        <p>
+          <% if @contract.previous_progress_report %>
             <strong>Burn based on estimated completion percentage</strong>
             <%= number_to_currency(@contract.completion_burn) %> (<%= result_with_color(@contract.completion_burn_percentage) %>%)
-          </p>
-        <% end %>
+          <% end %>
+        </p>
         <% if @contract.is_billable? %>
           <div class="mt-3 row">
             <div class="col-sm-12 col-md-6">

--- a/app/views/contracts/team.html.erb
+++ b/app/views/contracts/team.html.erb
@@ -10,7 +10,7 @@
             <thead>
               <tr>
                 <th rowspan="2">Name</th>
-                <th rowspan="2">Role</th>
+                <th rowspan="2">Functional Area</th>
                 <th colspan="<%= @reporting_periods.count %>" class="text-center">
                   days in the last 4 months
                 </th>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -119,6 +119,9 @@
           </div>
         </div>
       </div>
+
+      <%= yield(:modals).html_safe %>
+
       <% if Rails.env.production? %>
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GOOGLE_ANALYTICS"] %>"></script>

--- a/app/views/progress_reports/_form.html.erb
+++ b/app/views/progress_reports/_form.html.erb
@@ -1,0 +1,65 @@
+<%= form_with(model: [contract, progress_report], local: true) do |form| %>
+  <% previous_report = contract.previous_progress_report(progress_report) %>
+  <% if previous_report %>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="main-card mb-3 card">
+          <div class="card-body">
+            <h5 class="card-title">Previous report</h5>
+            <p>
+              <%= previous_report.reporting_period.display_name %>,
+              <%= previous_report.percentage %>% complete.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <% if progress_report.errors.any? %>
+            <div id="error_explanation">
+              <h2><%= pluralize(progress_report.errors.count, "error") %> prohibited this progress_report from being saved:</h2>
+
+              <ul>
+                <% progress_report.errors.full_messages.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <div class="position-relative row form-group">
+            <%= form.label :reporting_period_id, class: "col-sm-2 col-form-label" %>
+            <div class="col-sm-10">
+              <%= form.collection_select :reporting_period_id, @reporting_periods, :id, :display_name,
+                {selected: progress_report.new_record? ? @active_period.id : progress_report.reporting_period_id}, class: 'form-control' %>
+            </div>
+          </div>
+          <div class="position-relative row form-group">
+            <%= form.label :percentage, 'Progress percentage', class: "col-sm-2 col-form-label" %>
+            <div class="col-sm-10">
+              <div class="input-group">
+                <%= form.text_field :percentage, class: 'form-control', step: 'any',
+                  type: 'number', min: previous_report&.percentage.to_f || 0.0, max: 100.0 %>
+                <div class="input-group-append">
+                  <div class="input-group-text">%</div>
+                </div>
+              </div>
+              <small class="form-text text-muted">
+                Please estimate how much of the contract is already complete in terms of scope.
+              </small>
+            </div>
+          </div>
+          <div class="position-relative row form-group">
+            <div class="col-sm-10 offset-sm-2">
+              <%= form.submit "Submit", class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/progress_reports/edit.html.erb
+++ b/app/views/progress_reports/edit.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Edit Project Progress" %>
+<% content_for :actions,
+  link_to('Back', @contract, class: 'btn btn-sm btn-outline-secondary') %>
+
+<%= render 'form', progress_report: @progress_report,
+  reporting_periods: @reporting_periods, active_period: @active_period,
+  contract: @contract %>

--- a/app/views/progress_reports/new.html.erb
+++ b/app/views/progress_reports/new.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, "Track Project Progress" %>
+<% content_for :actions,
+  link_to('Back', @contract, class: 'btn btn-sm btn-outline-secondary') %>
+
+<%= render 'form', progress_report: @progress_report,
+  reporting_periods: @reporting_periods, active_period: @active_period,
+  contract: @contract %>

--- a/app/views/reporting_periods/reports.html.erb
+++ b/app/views/reporting_periods/reports.html.erb
@@ -18,7 +18,7 @@
             <tr>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Contract</th>
               <th>Percentage</th>
               <th>Days</th>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,7 +10,7 @@
             <tr>
               <th>User</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Reporting period</th>
               <th colspan="3"></th>
             </tr>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <strong>Role:</strong>
+  <strong>Functional Area:</strong>
   <%= @report.role_id %>
 </p>
 

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Editing Role" %>
+<% content_for :title, "Editing Functional Area" %>
 <% content_for :actions,
   link_to('Show', @role, class: 'btn btn-sm btn-outline-primary').concat(
     link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary')) %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "Roles" %>
+<% content_for :title, "Functional Areas" %>
 <% content_for :actions,
-  link_to('New Role', new_role_path, class: 'btn btn-sm btn-outline-primary') %>
+  link_to('New Functional Area', new_role_path, class: 'btn btn-sm btn-outline-primary') %>
 
 <div class="row">
   <div class="col-md-12">

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "New Role" %>
+<% content_for :title, "New Functional Area" %>
 <% content_for :actions,
   link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary') %>
 

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Role - #{@role.name}" %>
+<% content_for :title, "Functional Area - #{@role.name}" %>
 <% content_for :actions,
   link_to('Edit', edit_role_path(@role), class: 'btn btn-sm btn-outline-primary').concat(
     link_to('Back', roles_path, class: 'btn btn-sm btn-outline-secondary')) %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -83,7 +83,7 @@
         <li>
           <%= link_to :roles, class: (controller_name == 'roles' && 'mm-active') do %>
             <i class="metismenu-icon"></i>
-            Roles
+            Functional Areas
           <% end %>
         </li>
         <li>

--- a/app/views/teams/members.html.erb
+++ b/app/views/teams/members.html.erb
@@ -9,7 +9,7 @@
           <thead>
             <tr>
               <th>Name</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <th>Email</th>
               <th></th>
             </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
             <tr>
               <th>Name</th>
               <th>Team</th>
-              <th>Role</th>
+              <th>Functional Area</th>
               <% if current_user.admin? %>
                 <th>Rate</th>
                 <th>Dedication</th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,7 +21,7 @@
         </p>
 
         <p>
-          <strong>Roles:</strong>
+          <strong>Functional Area:</strong>
           <%= @user.role&.name %>
         </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   end
   resources :projects
   resources :contracts do
+    resources :progress_reports, only: [:new, :create, :edit, :update]
     member do
       get 'reports'
       get 'team'

--- a/db/migrate/20200208175311_create_budget_lines.rb
+++ b/db/migrate/20200208175311_create_budget_lines.rb
@@ -1,0 +1,12 @@
+class CreateBudgetLines < ActiveRecord::Migration[6.0]
+  def change
+    create_table :budget_lines do |t|
+      t.references :contract, null: false, foreign_key: true
+      t.references :role, foreign_key: true
+      t.float :percentage
+      t.string :details
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200208195756_create_progress_reports.rb
+++ b/db/migrate/20200208195756_create_progress_reports.rb
@@ -1,0 +1,12 @@
+class CreateProgressReports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :progress_reports do |t|
+      t.references :reporting_period, null: false, foreign_key: true
+      t.references :contract, null: false, foreign_key: true
+      t.float :percentage
+      t.float :delta
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_08_175311) do
+ActiveRecord::Schema.define(version: 2020_02_08_195756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,17 @@ ActiveRecord::Schema.define(version: 2020_02_08_175311) do
     t.string "details"
     t.index ["contract_id"], name: "index_non_staff_costs_on_contract_id"
     t.index ["reporting_period_id"], name: "index_non_staff_costs_on_reporting_period_id"
+  end
+
+  create_table "progress_reports", force: :cascade do |t|
+    t.bigint "reporting_period_id", null: false
+    t.bigint "contract_id", null: false
+    t.float "percentage"
+    t.float "delta"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["contract_id"], name: "index_progress_reports_on_contract_id"
+    t.index ["reporting_period_id"], name: "index_progress_reports_on_reporting_period_id"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -145,6 +156,8 @@ ActiveRecord::Schema.define(version: 2020_02_08_175311) do
   add_foreign_key "contracts", "projects"
   add_foreign_key "non_staff_costs", "contracts"
   add_foreign_key "non_staff_costs", "reporting_periods"
+  add_foreign_key "progress_reports", "contracts"
+  add_foreign_key "progress_reports", "reporting_periods"
   add_foreign_key "projects", "teams"
   add_foreign_key "report_parts", "contracts"
   add_foreign_key "report_parts", "reports"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_05_174106) do
+ActiveRecord::Schema.define(version: 2020_02_08_175311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "budget_lines", force: :cascade do |t|
+    t.bigint "contract_id", null: false
+    t.bigint "role_id"
+    t.float "percentage"
+    t.string "details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["contract_id"], name: "index_budget_lines_on_contract_id"
+    t.index ["role_id"], name: "index_budget_lines_on_role_id"
+  end
 
   create_table "contracts", force: :cascade do |t|
     t.string "name"
@@ -129,6 +140,8 @@ ActiveRecord::Schema.define(version: 2020_02_05_174106) do
     t.index ["team_id"], name: "index_users_on_team_id"
   end
 
+  add_foreign_key "budget_lines", "contracts"
+  add_foreign_key "budget_lines", "roles"
   add_foreign_key "contracts", "projects"
   add_foreign_key "non_staff_costs", "contracts"
   add_foreign_key "non_staff_costs", "reporting_periods"

--- a/test/factories/budget_lines.rb
+++ b/test/factories/budget_lines.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: budget_lines
+#
+#  id          :bigint           not null, primary key
+#  contract_id :bigint           not null
+#  role_id     :bigint
+#  percentage  :float
+#  details     :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryBot.define do
   factory :budget_line do
     contract { nil }

--- a/test/factories/budget_lines.rb
+++ b/test/factories/budget_lines.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :budget_line do
+    contract { nil }
+    role { nil }
+    percentage { 1.5 }
+    details { "MyString" }
+  end
+end

--- a/test/factories/budget_lines.rb
+++ b/test/factories/budget_lines.rb
@@ -16,6 +16,6 @@ FactoryBot.define do
     contract { nil }
     role { nil }
     percentage { 1.5 }
-    details { "MyString" }
+    details { 'MyString' }
   end
 end

--- a/test/factories/contracts.rb
+++ b/test/factories/contracts.rb
@@ -14,6 +14,8 @@
 #  aasm_state       :string
 #  percent_complete :float
 #  code             :string
+#  notes            :text
+#  summary          :text
 #
 
 FactoryBot.define do

--- a/test/factories/progress_reports.rb
+++ b/test/factories/progress_reports.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: progress_reports
+#
+#  id                  :bigint           not null, primary key
+#  reporting_period_id :bigint           not null
+#  contract_id         :bigint           not null
+#  percentage          :float
+#  delta               :float
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 FactoryBot.define do
   factory :progress_report do
     reporting_period { nil }

--- a/test/factories/progress_reports.rb
+++ b/test/factories/progress_reports.rb
@@ -13,9 +13,9 @@
 
 FactoryBot.define do
   factory :progress_report do
-    reporting_period { nil }
-    contract { nil }
-    percentage { 1.5 }
-    delta { 1.5 }
+    association :reporting_period
+    association :contract
+    percentage { 25 }
+    delta { 25 }
   end
 end

--- a/test/factories/progress_reports.rb
+++ b/test/factories/progress_reports.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :progress_report do
+    reporting_period { nil }
+    contract { nil }
+    percentage { 1.5 }
+    delta { 1.5 }
+  end
+end

--- a/test/models/budget_line_test.rb
+++ b/test/models/budget_line_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BudgetLineTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/budget_line_test.rb
+++ b/test/models/budget_line_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: budget_lines
+#
+#  id          :bigint           not null, primary key
+#  contract_id :bigint           not null
+#  role_id     :bigint
+#  percentage  :float
+#  details     :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require 'test_helper'
 
 class BudgetLineTest < ActiveSupport::TestCase

--- a/test/models/contract_test.rb
+++ b/test/models/contract_test.rb
@@ -14,6 +14,8 @@
 #  aasm_state       :string
 #  percent_complete :float
 #  code             :string
+#  notes            :text
+#  summary          :text
 #
 
 require 'test_helper'

--- a/test/models/progress_report_test.rb
+++ b/test/models/progress_report_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: progress_reports
+#
+#  id                  :bigint           not null, primary key
+#  reporting_period_id :bigint           not null
+#  contract_id         :bigint           not null
+#  percentage          :float
+#  delta               :float
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 require 'test_helper'
 
 class ProgressReportTest < ActiveSupport::TestCase

--- a/test/models/progress_report_test.rb
+++ b/test/models/progress_report_test.rb
@@ -25,11 +25,11 @@ class ProgressReportTest < ActiveSupport::TestCase
     reporting_period2 = create(:reporting_period, date: 2.months.ago)
     reporting_period3 = create(:reporting_period, date: 1.months.ago)
     create(:progress_report, percentage: 25, contract: contract,
-           reporting_period: reporting_period1)
+                             reporting_period: reporting_period1)
     create(:progress_report, percentage: 35, contract: contract,
-           reporting_period: reporting_period2)
+                             reporting_period: reporting_period2)
     progress_report = create(:progress_report, percentage: 55, contract: contract,
-           reporting_period: reporting_period3)
+                                               reporting_period: reporting_period3)
     assert_equal 20, progress_report.delta
   end
 end

--- a/test/models/progress_report_test.rb
+++ b/test/models/progress_report_test.rb
@@ -14,7 +14,22 @@
 require 'test_helper'
 
 class ProgressReportTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test '#calculate_delta makes delta like percentage when adding the first report' do
+    progress_report = create(:progress_report, percentage: 25)
+    assert_equal 25, progress_report.delta
+  end
+
+  test '#calculate_delta saves difference when creating a progress report after an existing one' do
+    contract = create(:contract)
+    reporting_period1 = create(:reporting_period, date: 3.months.ago)
+    reporting_period2 = create(:reporting_period, date: 2.months.ago)
+    reporting_period3 = create(:reporting_period, date: 1.months.ago)
+    create(:progress_report, percentage: 25, contract: contract,
+           reporting_period: reporting_period1)
+    create(:progress_report, percentage: 35, contract: contract,
+           reporting_period: reporting_period2)
+    progress_report = create(:progress_report, percentage: 55, contract: contract,
+           reporting_period: reporting_period3)
+    assert_equal 20, progress_report.delta
+  end
 end

--- a/test/models/progress_report_test.rb
+++ b/test/models/progress_report_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProgressReportTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
(review after https://github.com/Vizzuality/vizz_trackr/pull/42)

This Pull Requests updates the progress reporting so that it can be captured by Reporting Period instead of a single value. For each new report it will keep track of the delta, to make it easier to calculate income per month.

This information is managed from the contract show page for now, there might be an advantage in allowing bulk updating this information, but is not done in this PR.

![Screenshot 2020-02-10 at 08 53 18](https://user-images.githubusercontent.com/10764/74134711-e979ff00-4be2-11ea-8a6d-9db11c145ab6.png)
![Screenshot 2020-02-10 at 08 53 28](https://user-images.githubusercontent.com/10764/74134717-eb43c280-4be2-11ea-82a8-8ad54314849b.png)
![Screenshot 2020-02-10 at 08 53 37](https://user-images.githubusercontent.com/10764/74134720-ec74ef80-4be2-11ea-8c5c-02183981b8a0.png)
![Screenshot 2020-02-10 at 08 53 43](https://user-images.githubusercontent.com/10764/74134723-ed0d8600-4be2-11ea-9daa-d45303881c06.png)
![Screenshot 2020-02-10 at 08 53 50](https://user-images.githubusercontent.com/10764/74134724-eda61c80-4be2-11ea-813b-0105e7828016.png)
![Screenshot 2020-02-10 at 08 53 59](https://user-images.githubusercontent.com/10764/74134725-eda61c80-4be2-11ea-8e93-f272ce8bada8.png)
